### PR TITLE
Log lists of fully successful, partial success (error) and failed transforms of ontologies

### DIFF
--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -1,6 +1,5 @@
 import tempfile
-import kgx  # type: ignore
-from kgx.cli import transform # type: ignore
+import kgx.cli  # type: ignore
 from kgx.config import get_logger # type: ignore
 from tqdm import tqdm  # type: ignore
 import yaml  # type: ignore
@@ -49,14 +48,14 @@ def kgx_transform(input_file: list, input_format: str,
     success = True
     errors = False
     try:
-        transform(inputs=input_file,
-                      input_format=input_format,
-                      output=output_file,
-                      output_format=output_format)
-        if 30 in logger._cache and logger._cache[30]:
-            logger.error("Encountered errors in transforming or parsing.")
+        kgx.cli.transform(inputs=input_file,
+                          input_format=input_format,
+                          output=output_file,
+                          output_format=output_format)
+        if hasattr(logger, "_cache") and 30 in logger._cache and logger._cache[30]:  # type: ignore
+            logger.error("Encountered errors in transforming or parsing.")  # type: ignore
             errors = True
-            logger._cache.clear()
+            logger._cache.clear()  # type: ignore
     except (FileNotFoundError,
             SAXParseException,
             ParserError,
@@ -87,7 +86,7 @@ def run_transform(skip_list: list = [], log_dir="logs") -> None:
 
     # Get the OBO Foundry list YAML and process each
     yaml_onto_list_filtered = retrieve_obofoundry_yaml(skip_list=skip_list)
-    
+
     successful_transforms = []
     errored_transforms = []
     failed_transforms = []
@@ -126,15 +125,17 @@ def run_transform(skip_list: list = [], log_dir="logs") -> None:
 
             pbar.close()
 
+            # TODO: Decide whether we need to transform based on version IRI
+
             tf_output_dir = tempfile.mkdtemp(prefix=ontology_name)
 
             # Use kgx to transform, but save errors to log
-            transform_errors = []
+            transform_errors: list = []
             success, errors = kgx_transform(input_file=[tfile.name],
-                                    input_format='owl',
-                                    output_file=os.path.join(tf_output_dir, ontology_name),
-                                    output_format='tsv',
-                                    logger=kgx_logger)
+                                            input_format='owl',
+                                            output_file=os.path.join(tf_output_dir, ontology_name),
+                                            output_format='tsv',
+                                            logger=kgx_logger)
 
             # Check file size and fail/warn if nodes|edge file is empty
             for filename in os.listdir(tf_output_dir):
@@ -154,16 +155,20 @@ def run_transform(skip_list: list = [], log_dir="logs") -> None:
                 kg_obo_logger.warning(f"Failed to transform {ontology_name}")
                 failed_transforms.append(ontology_name)
 
-            # query kghub/[ontology]/current/*hash*
-        
-        # kghub/obo2kghub/bfo/2021_08_16|current/nodes|edges.tsv|date-hash
-        
+        # TODO: upload to S3
+        # make a version file
+        # make an index.html for s3_bucket/kg-obo/[this ontology]/[version]/
+        # make an index.html for s3_bucket/kg-obo/[this ontology]/
+        # push to s3:
+        # push s3_bucket/kg-obo/[this ontology]/[version]
+        # push s3_bucket/kg-obo/[this ontology]/current
+
     kg_obo_logger.info(f"Successfully transformed {len(successful_transforms)}: {successful_transforms}")
-        
+
     if len(errored_transforms) > 0:
         kg_obo_logger.info(f"Incompletely transformed due to errors {len(errored_transforms)}: {errored_transforms}")
 
     if len(failed_transforms) > 0:
         kg_obo_logger.info(f"Failed to transform {len(failed_transforms)}: {failed_transforms}")
-        
-        # upload to S3
+
+    # TODO: make new index.html for s3_bucket/kg-obo/

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -32,11 +32,11 @@ class TestRunTransform(TestCase):
     def test_kgx_transform(self, mock_kgx_transform) -> None:
         ret_val = kgx_transform(**self.kgx_transform_kwargs)
         self.assertTrue(mock_kgx_transform.called)
-        self.assertTrue(ret_val)
+        self.assertTrue(ret_val[0])
 
         mock_kgx_transform.side_effect = Exception(mock.Mock())
         mock_kgx_transform.side_effect.isEnabledFor = mock.Mock()
         mock_kgx_transform.side_effect._log = mock.Mock()
         ret_val = kgx_transform(**self.kgx_transform_kwargs)
         self.assertTrue(mock_kgx_transform.called)
-        self.assertFalse(ret_val)
+        self.assertFalse(ret_val[0])


### PR DESCRIPTION
See issue #5 - logging individual errors is already covered, but now all transforms are in three bins: complete success, success with errors (e.g., kgx can't load a node or nodes), and complete failure (OBO won't parse at all).

Definitely broke a few tests here.