### PR TITLE
Avoid incomplete uploads

### DIFF
--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -374,16 +374,12 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
                 kg_obo.upload.upload_index_files(ontology_name, versioned_obo_path)
 
+                # Upload the most recently transformed version only
                 kg_obo_logger.info("Uploading...")
-                if bucket != "bucket":
-                    if not s3_test:
-                        kg_obo.upload.upload_dir_to_s3(os.path.dirname(os.path.dirname(versioned_obo_path)),bucket,
-                                                       remote_path,make_public=True)
-                    else:
-                        kg_obo.upload.mock_upload_dir_to_s3(os.path.dirname(os.path.dirname(versioned_obo_path)),bucket,
-                                                       remote_path,make_public=True)
+                if s3_test:
+                    kg_obo.upload.mock_upload_dir_to_s3(versioned_obo_path,bucket,remote_path,make_public=True)
                 else:
-                    kg_obo_logger.info("Bucket name not provided. Not uploading.")
+                    kg_obo.upload.upload_dir_to_s3(versioned_obo_path,bucket,remote_path,make_public=True)
 
                 if not save_local:
                     for filename in os.listdir(data_dir):

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -371,8 +371,8 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
                 if not s3_test:
                     track_obo_version(ontology_name, owl_iri, owl_version, bucket)
-
-                kg_obo.upload.upload_index_files(ontology_name, versioned_obo_path)
+                    # Update indexes for this version and OBO only
+                    kg_obo.upload.upload_index_files(bucket, remote_path, versioned_obo_path, data_dir, update_root=False)
 
                 # Upload the most recently transformed version only
                 # TODO: ignore uploading index files - they should be handled by upload_index_files
@@ -382,15 +382,6 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
                     kg_obo.upload.mock_upload_dir_to_s3(versioned_obo_path,bucket,versioned_remote_path,make_public=True)
                 else:
                     kg_obo.upload.upload_dir_to_s3(versioned_obo_path,bucket,versioned_remote_path,make_public=True)
-
-                if not save_local:
-                    for filename in os.listdir(data_dir):
-                        file_path = os.path.join(data_dir, filename)
-                        if filename != track_file_local_path:
-                            if os.path.isfile(file_path) or os.path.islink(file_path):
-                                os.unlink(file_path)
-                            elif os.path.isdir(file_path):
-                                shutil.rmtree(file_path)
 
             elif success and errors:
                 kg_obo_logger.info(f"Completed transform of {ontology_name} with errors")
@@ -406,6 +397,19 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
     if len(failed_transforms) > 0:
         kg_obo_logger.info(f"Failed to transform {len(failed_transforms)}: {failed_transforms}")
+
+    if not s3_test:
+        # Update the root index
+        kg_obo.upload.upload_index_files(bucket, remote_path, data_dir, data_dir, update_root=True)
+    
+    if not save_local:
+        for filename in os.listdir(data_dir):
+            file_path = os.path.join(data_dir, filename)
+            if filename != track_file_local_path:
+                if os.path.isfile(file_path) or os.path.islink(file_path):
+                    os.unlink(file_path)
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
 
     # Now un-set the lockfile
     if s3_test:

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -375,11 +375,13 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
                 kg_obo.upload.upload_index_files(ontology_name, versioned_obo_path)
 
                 # Upload the most recently transformed version only
+                # TODO: ignore uploading index files - they should be handled by upload_index_files
                 kg_obo_logger.info("Uploading...")
+                versioned_remote_path = os.path.join(remote_path,ontology_name,owl_version)
                 if s3_test:
-                    kg_obo.upload.mock_upload_dir_to_s3(versioned_obo_path,bucket,remote_path,make_public=True)
+                    kg_obo.upload.mock_upload_dir_to_s3(versioned_obo_path,bucket,versioned_remote_path,make_public=True)
                 else:
-                    kg_obo.upload.upload_dir_to_s3(versioned_obo_path,bucket,remote_path,make_public=True)
+                    kg_obo.upload.upload_dir_to_s3(versioned_obo_path,bucket,versioned_remote_path,make_public=True)
 
                 if not save_local:
                     for filename in os.listdir(data_dir):

--- a/kg_obo/upload.py
+++ b/kg_obo/upload.py
@@ -3,6 +3,7 @@ import boto3  # type: ignore
 from moto import mock_s3 # type: ignore
 import os
 import logging
+from time import time
 
 def check_tracking(s3_bucket: str, s3_bucket_dir: str) -> bool:
     """
@@ -247,17 +248,20 @@ def mock_upload_dir_to_s3(local_directory: str, s3_bucket: str, s3_bucket_dir: s
     for bucket_object in conn.Bucket(s3_bucket).objects.all():
         print(bucket_object.key)
 
-def upload_index_files(ontology_name: str, versioned_obo_path: str) -> None:
+def upload_index_files(bucket: str, remote_path: str, local_path: str, data_dir: str, update_root=False) -> None:
     """
-    Checks the root, obo directory, and version directory,
+    Checks the obo directory and version directory,
     creating index.html where it does not exist.
+    (Or, if update_root is True, just the given directory and not its parent).
     If index exists, update it if needed.
-    :param ontology_name: str of ontology ID
-    :param versioned_obo_path: str of directory containing this ontology version
+    :param bucket: str of S3 bucket
+    :param remote_path: str of path to upload to
+    :param versioned_obo_path: str of directory containing the files to create index for
+    :param data_dir: str of the data directory, so we can get the relative path
+    :param update_root: bool, True to update root index (in this case, versioned_obo_path will be the data_dir)
     """
 
-    # At present this will rebuild the root index at every transform/upload -
-    # this is intentional, or we may not write updates if the process exits early
+    client = boto3.client('s3')
 
     ifilename = "index.html"
 
@@ -279,21 +283,34 @@ def upload_index_files(ontology_name: str, versioned_obo_path: str) -> None:
 </html>
 """
 
-    check_dirs = [versioned_obo_path,
-                    os.path.dirname(versioned_obo_path),
-                    os.path.dirname(os.path.dirname(versioned_obo_path))]
+    if not update_root:
+        # Create/update index for current OBO version and all versions of this OBO
+        check_dirs = [local_path, os.path.dirname(local_path)]
+    else:
+        # Update root index
+        check_dirs = [local_path]
 
     for dir in check_dirs:
 
         current_path = os.path.join(dir,ifilename)
         current_files = os.listdir(dir)
 
-        #Even if index exists, just rebuild it
         with open(current_path, 'w') as ifile:
             ifile.write(index_head.format(this_dir=dir))
             for filename in current_files:
-                if filename != 'index.html':
+                if filename != ifilename:
                     ifile.write(f"\t\t<li>\n\t\t\t<a href={filename}>{filename}</a>\n\t\t</li>\n")
             ifile.write(index_tail)
         
-        print(f"Created index for {dir}")
+        
+        path_only = os.path.relpath(local_path, data_dir)
+        current_remote_path = os.path.join(remote_path, path_only)
+        print(f"Created index for {current_remote_path}")
+
+        # Just to be safe, delete the index if it already exists
+        # Shouln't really be necessary but I am superstitious
+        try:
+            client.delete_object(Bucket=bucket, Key=current_remote_path)
+        except Exception:
+            pass
+        client.put_object(Bucket=bucket, Key=current_remote_path)


### PR DESCRIPTION
The uploading function was doing a recursive traversal across multiple data directories, which caused incomplete transforms to get uploaded along with complete ones. This fixes that.