### PR TITLE
Deal with aro version run jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,8 @@ pipeline {
                             string(credentialsId: 'aws_kg_hub_secret_key', variable: 'AWS_SECRET_ACCESS_KEY')]) {
                             script {
                                 if (env.BRANCH_NAME != 'main') {
-                                    echo "Will not transform if not on correct branch."
+                                    echo "Transforming with --s3_test since we aren't on main/master branch"
+                                    sh '. venv/bin/activate && env && python3.8 run.py --s3_test -bucket fake_bucket'
                                 } else {
                                     sh '. venv/bin/activate && env && python3.8 run.py --bucket kg-hub-public-data'
                                 }

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -6,7 +6,6 @@ import yaml  # type: ignore
 import requests  # type: ignore
 from datetime import datetime
 from io import StringIO
-
 import boto3  # type: ignore
 
 import os
@@ -21,6 +20,8 @@ from rdflib.exceptions import ParserError # type: ignore
 
 import kg_obo.obolibrary_utils
 import kg_obo.upload
+from urllib.parse import quote
+
 
 def retrieve_obofoundry_yaml(
         yaml_url: str = 'https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.yml',
@@ -104,7 +105,7 @@ def kgx_transform(input_file: list, input_format: str,
         if sum(error_collect.values()) > 0:  # type: ignore
             logger.error(f"Encountered errors in transforming or parsing: {error_collect}")  # type: ignore
             errors = True
-    
+
     except (FileNotFoundError,
             SAXParseException,
             ParserError,
@@ -132,7 +133,7 @@ def get_owl_iri(input_file_name: str) -> tuple:
     """
 
     iri_tag = b'owl:versionIRI rdf:resource=\"(.*)\"'
-    date_tag = b'oboInOwl:date rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">(.*)'
+    date_tag = b'oboInOwl:date rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">([^\<]+)'
 
     iri = "release"
     version = "release"
@@ -140,21 +141,21 @@ def get_owl_iri(input_file_name: str) -> tuple:
     try:
         with open(input_file_name, 'rb', 0) as owl_file, \
             mmap.mmap(owl_file.fileno(), 0, access=mmap.ACCESS_READ) as owl_string:
-            iri_search = re.search(iri_tag, owl_string) #type: ignore
-            date_search = re.search(date_tag, owl_string) #type: ignore
-            #mypy doesn't like re and mmap objects
+            iri_search = re.search(iri_tag, owl_string)  # type: ignore
+            date_search = re.search(date_tag, owl_string)  # type: ignore
+            # mypy doesn't like re and mmap objects
             if iri_search:
                 iri = (iri_search.group(1)).decode("utf-8")
                 try:
-                    version = (iri.split("/"))[-2]
+                    version = quote((iri.split("/"))[-2])
                 except IndexError:
                     pass
             else:
                 print("Version IRI not found.")
                 if date_search:
                     date = (date_search.group(1)).decode("utf-8")
-                    iri = date
-                    version = date
+                    iri = ''
+                    version = quote(date)
                 else:
                     print("Release date not found.")
     except ValueError: #Should not happen unless OWL definitions are missing/broken
@@ -426,7 +427,7 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
             else:
                 kg_obo_logger.warning(f"Failed to transform {ontology_name}")
                 failed_transforms.append(ontology_name)
-            
+
             # Clean up any incomplete transform leftovers
             if not success:
                 for filename in os.listdir(base_obo_path):
@@ -450,7 +451,7 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
             kg_obo_logger.info(f"Created root index at {remote_path}")
         else:
             kg_obo_logger.info(f"Failed to create root index at {remote_path}")
-    
+
     if not save_local:
         for filename in os.listdir(data_dir):
             file_path = os.path.join(data_dir, filename)
@@ -467,6 +468,6 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
     else:
         if not kg_obo.upload.set_lock(bucket,lock_file_remote_path,unlock=True):
             sys.exit("Could not set lock file on remote server. Exiting...")
-    
+
     return True
 

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -131,7 +131,8 @@ def get_owl_iri(input_file_name: str) -> tuple:
     :param input_file_name: name of OWL format file to extract IRI from
     :return: tuple of (str of IRI, str of version)
     """
-
+ 
+    # Most IRIs take this format - there are some exceptions
     iri_tag = b'owl:versionIRI rdf:resource=\"(.*)\"'
     date_tag = b'oboInOwl:date rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">([^\<]+)'
 
@@ -147,7 +148,11 @@ def get_owl_iri(input_file_name: str) -> tuple:
             if iri_search:
                 iri = (iri_search.group(1)).decode("utf-8")
                 try:
-                    version = quote((iri.split("/"))[-2])
+                    raw_version = (iri.split("/"))[-2]
+                    if raw_version == "fao":
+                        version = quote((iri.split("/"))[-3])
+                    else:
+                        version = quote(raw_version)
                 except IndexError:
                     pass
             else:

--- a/run.py
+++ b/run.py
@@ -51,6 +51,7 @@ def run(skip, get_only, bucket, save_local, s3_test):
                 print("Could not remove lock file due to yet another error.")
             else:
                 print("Lock removed.")
+        sys.exit(-1)
 
 if __name__ == '__main__':
   run()

--- a/tests/resources/download_ontology/aro_SNIPPET.owl
+++ b/tests/resources/download_ontology/aro_SNIPPET.owl
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/antibiotic_resistance.owl#"
+     xml:base="http://purl.obolibrary.org/obo/antibiotic_resistance.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/antibiotic_resistance.owl">
+        <oboInOwl:auto-generated-by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cv2obo</oboInOwl:auto-generated-by>
+        <oboInOwl:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">05:07:2021 15:21</oboInOwl:date>
+        <oboInOwl:default-namespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antibiotic_resistance</oboInOwl:default-namespace>
+        <oboInOwl:hasOBOFormatVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.2</oboInOwl:hasOBOFormatVersion>
+        <oboInOwl:saved-by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARD</oboInOwl:saved-by>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#auto-generated-by -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#auto-generated-by"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#date -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#date"/>
+ 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 
 from kg_obo.transform import run_transform, kgx_transform, download_ontology, \
     get_owl_iri, retrieve_obofoundry_yaml, track_obo_version
-
+from urllib.parse import quote
 
 class TestRunTransform(TestCase):
 
@@ -174,6 +174,10 @@ class TestRunTransform(TestCase):
         with pytest.raises(Exception):
             iri = get_owl_iri('')
 
+    def test_get_owl_iri_for_aro(self):
+        iri = get_owl_iri('tests/resources/download_ontology/aro_SNIPPET.owl')
+        self.assertEqual(iri, ('', quote('05:07:2021 15:21')))
+
     def test_get_owl_iri_bad_input(self):
         iri = get_owl_iri('tests/resources/download_ontology/bfo_NO_VERSION_IRI.owl')
         self.assertEqual(("release", "release"), iri)
@@ -194,7 +198,7 @@ class TestRunTransform(TestCase):
         iri = ""
         version = ""
         bucket = "test"
-        track_obo_version(name, iri, version, bucket, 
+        track_obo_version(name, iri, version, bucket,
                           track_file_local_path="tests/resources/tracking.yaml",
                           track_file_remote_path="tests/resources/tracking.yaml")
         self.assertTrue(mock_boto.called)


### PR DESCRIPTION
A few changes:

- add unit test to test parsing of weird version info in `aro.owl`
- escape metacharacters in parsed version info, since these are used for directory names
- run `run.py` with `--s3_test` when not on `main|master` branch
- return -1 when `run.py` exits because of an exception, so that Jenkins knows it died