### PR TITLE
Changes to ROBOT behavior; attempts to resolve build hangs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,9 +77,9 @@ pipeline {
                             script {
                                 if (env.BRANCH_NAME != 'main') {
                                     echo "Transforming with --s3_test since we aren't on main/master branch"
-                                    sh '. venv/bin/activate && env && python3.8 run.py --s3_test --bucket fake_bucket --no_dl_progress --force_index_refresh --robot_path robot'
+                                    sh '. venv/bin/activate && env && python3.8 run.py --s3_test --bucket fake_bucket --no_dl_progress --force_index_refresh'
                                 } else {
-                                    sh '. venv/bin/activate && env && python3.8 run.py --bucket kg-hub-public-data --no_dl_progress --force_index_refresh --robot_path robot'
+                                    sh '. venv/bin/activate && env && python3.8 run.py --bucket kg-hub-public-data --no_dl_progress --force_index_refresh'
                                 }
                             }
                     }

--- a/kg_obo/robot_utils.py
+++ b/kg_obo/robot_utils.py
@@ -41,13 +41,14 @@ def initialize_robot(robot_path: str) -> list:
     return [robot_command, env]
 
 
-def relax_owl(robot_path: str, input_owl: str, output_owl: str) -> None:
+def relax_owl(robot_path: str, input_owl: str, output_owl: str, robot_env: dict) -> None:
     """
     This method runs the ROBOT relax command on a single OBO.
     Has a three-hour timeout limit - process is killed if it takes this long.
     :param robot_path: Path to ROBOT files
     :param input_owl: Ontology file to be relaxed
     :param output_owl: Ontology file to be created (needs valid ROBOT suffix)
+    :param robot_env: dict of environment variables, including ROBOT_JAVA_ARGS
     :return: None
     """
 
@@ -59,16 +60,18 @@ def relax_owl(robot_path: str, input_owl: str, output_owl: str) -> None:
             '--input', input_owl, 
             '--output', output_owl,
             '--vvv',
+            _env=robot_env,
             _timeout=10800 
     )
 
-def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str) -> None:
+def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str, robot_env: dict) -> None:
     """
     This method runs a merge and convert ROBOT command on a single OBO.
     Has a three-hour timeout limit - process is killed if it takes this long.
     :param robot_path: Path to ROBOT files
     :param input_owl: Ontology file to be relaxed
     :param output_owl: Ontology file to be created (needs valid ROBOT suffix)
+    :param robot_env: dict of environment variables, including ROBOT_JAVA_ARGS
     :return: None
     """
 
@@ -81,5 +84,6 @@ def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str) -> N
             'convert', 
             '--output', output_owl,
             '--vvv',
+            _env=robot_env,
             _timeout=10800 
     )

--- a/kg_obo/robot_utils.py
+++ b/kg_obo/robot_utils.py
@@ -28,12 +28,10 @@ def initialize_robot(robot_path: str) -> list:
     chmod("+x","robot")
 
     # Declare environment variables
-    env = dict(os.environ)
+    env = os.environ.copy()
     # (JDK compatibility issue: https://stackoverflow.com/questions/49962437/unrecognized-vm-option-useparnewgc-error-could-not-create-the-java-virtual)
     # env['ROBOT_JAVA_ARGS'] = '-Xmx8g -XX:+UseConcMarkSweepGC' # for JDK 9 and older
     env['ROBOT_JAVA_ARGS'] = '-Xmx12g -XX:+UseG1GC'  # For JDK 10 and over
-    env['PATH'] = os.environ['PATH']
-    env['PATH'] += os.pathsep + robot_path
 
     try:
         robot_command = sh.Command(robot_path)
@@ -53,11 +51,14 @@ def relax_owl(robot_path: str, input_owl: str, output_owl: str) -> None:
     :return: None
     """
 
+    print(f"Relaxing {input_owl} to {output_owl}...")
+
     robot_command = sh.Command(robot_path)
 
     robot_command('relax',
             '--input', input_owl, 
             '--output', output_owl,
+            '--vvv',
             _timeout=10800 
     )
 
@@ -71,11 +72,14 @@ def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str) -> N
     :return: None
     """
 
+    print(f"Merging and converting {input_owl} to {output_owl}...")
+
     robot_command = sh.Command(robot_path)
 
     robot_command('merge',
             '--input', input_owl,
             'convert', 
             '--output', output_owl,
+            '--vvv',
             _timeout=10800 
     )

--- a/kg_obo/robot_utils.py
+++ b/kg_obo/robot_utils.py
@@ -64,6 +64,8 @@ def relax_owl(robot_path: str, input_owl: str, output_owl: str, robot_env: dict)
             _timeout=10800 
     )
 
+    print("Complete.")
+
 def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str, robot_env: dict) -> None:
     """
     This method runs a merge and convert ROBOT command on a single OBO.
@@ -87,3 +89,5 @@ def merge_and_convert_owl(robot_path: str, input_owl: str, output_owl: str, robo
             _env=robot_env,
             _timeout=10800 
     )
+
+    print("Complete.")

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -726,10 +726,13 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
                 kg_obo_logger.info(this_output_msg)
 
             # Check results of all transforms
+            # If we didn't get JSON, that's acceptable
             for output_format in desired_output_formats:
-                if not all_success_and_errors[output_format][0]:
+                if output_format == 'tsv' and not all_success_and_errors[output_format][0]:
                     success = False
-                    break
+                if output_format == 'json' and not all_success_and_errors[output_format][0]:
+                    kg_obo_logger.warning("JSON transform failed!")
+                    errors = True
             for output_format in desired_output_formats:
                 if all_success_and_errors[output_format][1]:
                     errors = True

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -414,6 +414,11 @@ def get_file_diff(before_filename, after_filename) -> str:
     :param after_filename: str, name or path of second file
     :return: str containing all lines different between the files
     """
+
+    # Not currently called as it's too slow on large files
+    # and the resulting large diffs are stored in memory.
+    # TODO: replace with a call to shell diff -u
+
     diff_string = ""
     with open(before_filename, 'r') as before_file:
         with open(after_filename, 'r') as after_file:
@@ -676,13 +681,8 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
             before_count = get_file_length(tfile.name)
             after_count = get_file_length(tfile_relaxed.name)
-            diff = get_file_diff(tfile.name,tfile_relaxed.name)
-            diff_count = len(diff.splitlines())
-            if diff_count >1:
-                print(f"""Difference after relaxing:\n{diff_count} lines changed
-                    ({before_count} lines before, {after_count} after).""")
-            else:
-                print(f"{diff} after relaxing.")
+            kg_obo_logger.info(f"Before relax: {before_count} lines. After relax: {after_count} lines.")
+            print(f"Before relax: {before_count} lines. After relax: {after_count} lines.")
 
             if after_count == 0:
                 kg_obo_logger.error(f"ROBOT relaxing of {ontology_name} yielded an empty result!")
@@ -701,13 +701,8 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
                 before_count = get_file_length(tfile_relaxed.name)
                 after_count = get_file_length(tfile_merged.name)
-                diff = get_file_diff(tfile_relaxed.name,tfile_merged.name)
-                diff_count = len(diff.splitlines())
-                if diff_count >1:
-                    print(f"""Difference after merging:\n{diff_count} lines changed
-                        ({before_count} lines before, {after_count} after).""")
-                else:
-                    print(f"{diff} after merging.")
+                kg_obo_logger.info(f"Before merge: {before_count} lines. After merge: {after_count} lines.")
+                print(f"Before merge: {before_count} lines. After merge: {after_count} lines.")
 
                 if after_count == 0:
                     kg_obo_logger.error(f"ROBOT merging of {ontology_name} yielded an empty result!")

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -658,7 +658,8 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
 
             # Run ROBOT preprocessing here - relax all, then do merge -> convert if needed
             print(f"ROBOT preprocessing: relax {ontology_name}")
-            tfile_relaxed = tempfile.NamedTemporaryFile(delete=False,suffix="_relaxed.owl")
+            temp_suffix = f"_{ontology_name}_relaxed.owl"
+            tfile_relaxed = tempfile.NamedTemporaryFile(delete=False,suffix=temp_suffix)
             relax_owl(robot_path, tfile.name,tfile_relaxed.name)
             tfile_relaxed.close()
 
@@ -682,7 +683,8 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
             if need_imports:
                 
                 print(f"ROBOT preprocessing: merge and convert {ontology_name}")
-                tfile_merged = tempfile.NamedTemporaryFile(delete=False,suffix="_merged.owl")
+                temp_suffix = f"_{ontology_name}_merged.owl"
+                tfile_merged = tempfile.NamedTemporaryFile(delete=False,suffix=temp_suffix)
                 merge_and_convert_owl(robot_path,tfile_relaxed.name,tfile_merged.name)
                 tfile_merged.close()
 

--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -671,7 +671,7 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
             print(f"ROBOT preprocessing: relax {ontology_name}")
             temp_suffix = f"_{ontology_name}_relaxed.owl"
             tfile_relaxed = tempfile.NamedTemporaryFile(delete=False,suffix=temp_suffix)
-            relax_owl(robot_path, tfile.name,tfile_relaxed.name)
+            relax_owl(robot_path, tfile.name,tfile_relaxed.name,robot_env)
             tfile_relaxed.close()
 
             before_count = get_file_length(tfile.name)
@@ -696,7 +696,7 @@ def run_transform(skip: list = [], get_only: list = [], bucket="bucket",
                 print(f"ROBOT preprocessing: merge and convert {ontology_name}")
                 temp_suffix = f"_{ontology_name}_merged.owl"
                 tfile_merged = tempfile.NamedTemporaryFile(delete=False,suffix=temp_suffix)
-                merge_and_convert_owl(robot_path,tfile_relaxed.name,tfile_merged.name)
+                merge_and_convert_owl(robot_path,tfile_relaxed.name,tfile_merged.name,robot_env)
                 tfile_merged.close()
 
                 before_count = get_file_length(tfile_relaxed.name)

--- a/tests/test_robot_utils.py
+++ b/tests/test_robot_utils.py
@@ -14,10 +14,10 @@ class TestRobotUtils(TestCase):
 
     def test_relax_owl(self):
         robot_setup()
-        initialize_robot(self.robot_path)
-        relax_owl(self.robot_path, self.input_owl, self.output_owl)
+        robot_command, env = initialize_robot(self.robot_path)
+        relax_owl(self.robot_path, self.input_owl, self.output_owl, env)
 
     def test_merge_and_convert_owl(self):
         robot_setup()
-        initialize_robot(self.robot_path)
-        relax_owl(self.robot_path, self.input_owl, self.output_owl)
+        robot_command, env = initialize_robot(self.robot_path)
+        relax_owl(self.robot_path, self.input_owl, self.output_owl, env)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -147,12 +147,12 @@ class TestRunTransform(TestCase):
             self.assertTrue(mock_retrieve_obofoundry_yaml.called)
             self.assertTrue(mock_kgx_transform.called)
 
-        # Test if error raised when ROBOT not available
-        # though we also want to continue without it
-        with tempfile.TemporaryDirectory() as td:
+        # Test if we exit when ROBOT not available
+        with tempfile.TemporaryDirectory() as td,\
+                pytest.raises(SystemExit) as e:
             run_transform(log_dir=td,s3_test=True,robot_path="wrong")
-            self.assertRaises(ValueError)
-            self.assertTrue(mock_kgx_transform.called)
+            assert e.type == SystemExit
+            assert e.value.code == 1
 
         # test that we don't run transform if download of ontology fails
         with mock.patch('kg_obo.transform.download_ontology', return_value=False),\


### PR DESCRIPTION
* KG-OBO now quits if the path to ROBOT can't be resolved to a command
* If a JSON transform fails, we still upload the successful tsv edge/nodes
* Added more verbose output for debugging
* Pass Java env variables directly to ROBOT functions
* Removed call to get_file_diff - it is far too slow and memory-intensive for larger OBOs