### PR TITLE
Bypass grape install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ pipeline {
             }
         }
 
-        // Build step does some extra work to prep for Ensmallen 
         stage('Build kg-obo') {
             steps {
                 dir('./gitrepo') {
@@ -63,10 +62,7 @@ pipeline {
                             branch: env.BRANCH_NAME
                     )
                     sh '/usr/bin/python3.8 -m venv venv'
-                    sh 'curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly --profile default -y'
-                    sh 'export PATH=$PATH:$HOME/.cargo/bin'
-                    sh 'cargo install maturin'
-                    sh '. venv/bin/activate && pip install $ENSMALLEN_URL'
+                    sh '. venv/bin/activate'
                     sh './venv/bin/pip install .'
                 }
             }

--- a/run.py
+++ b/run.py
@@ -50,16 +50,6 @@ def run(skip, get_only, bucket, save_local, s3_test, no_dl_progress, force_index
         else:
             print("Operation encountered errors. See logs for details.")
 
-        print("Generating reports...")
-        if get_all_stats(skip, get_only, bucket, save_local):
-            print("Reports generated without errors. See stats directory.")
-            if kg_obo.upload.upload_reports(bucket):
-                print(f"Uploaded reports to {bucket}.")
-            else:
-                print(f"Could not upload reports to {bucket}.")
-        else:
-            print("Stats reports could not be generated.")
-
     except Exception as e:
         print(f"Encountered unresolvable error: {type(e)} - {e} ({e.args})")
         print("Removing lock due to error...")
@@ -72,6 +62,19 @@ def run(skip, get_only, bucket, save_local, s3_test, no_dl_progress, force_index
             else:
                 print("Lock removed.")
         sys.exit(-1)
+
+    print("Generating reports...")
+    try:
+        if get_all_stats(skip, get_only, bucket, save_local):
+            print("Reports generated without errors. See stats directory.")
+            if kg_obo.upload.upload_reports(bucket):
+                print(f"Uploaded reports to {bucket}.")
+            else:
+                print(f"Could not upload reports to {bucket}.")
+        else:
+            print("Stats reports could not be generated.")
+    except Exception as e:
+        print(f"Encountered unresolvable error while generating stats: {type(e)} - {e}")
 
 if __name__ == '__main__':
   run()

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,12 @@ test_deps = [
     'coveralls',
     'validate_version_code',
     'codacy-coverage',
-    'parameterized'
+    'parameterized',
+    'grape'
 ]
 
 extras = {
-    'test': test_deps,
+    'test': test_deps
 }
 
 setup(
@@ -71,8 +72,7 @@ setup(
         'moto[s3]',
         'sphinx_rtd_theme',
         'recommonmark',
-        'sh',
-        'grape'
+        'sh'
     ],
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ test_deps = [
     'coveralls',
     'validate_version_code',
     'codacy-coverage',
-    'parameterized',
-    'grape'
+    'parameterized'
 ]
 
 extras = {
@@ -72,7 +71,8 @@ setup(
         'moto[s3]',
         'sphinx_rtd_theme',
         'recommonmark',
-        'sh'
+        'sh',
+        'grape'
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
Most of KG-OBO doesn't use GraPE/ensmallen (yet) so we can bypass it for a Jenkins build by ~~moving the dependency to the test dependency list (so the tests will still work)~~ Tox doesn't know how to handle this, so GraPE is still a main dependency, we just try to catch the ImportError.

Stats functions will fail gracefully instead of encountering an ImportError.
Otherwise, if GraPE is installed, stats functions will run.