### PR TITLE
Fix for proper geo versioning

### DIFF
--- a/kg_obo/transform.py
+++ b/kg_obo/transform.py
@@ -235,7 +235,7 @@ def get_owl_iri(input_file_name: str) -> tuple:
             elif iri_about_tag_search: #In this case, we likely don't have a version
                 version_format = "versionInfo"
                 iri = (iri_about_tag_search.group(1)).decode("utf-8")
-                if ((iri.split("/"))[-1] in ["oae.owl", "opmi.owl", "ons.owl"]) or \
+                if ((iri.split("/"))[-1] in ["oae.owl", "opmi.owl", "ons.owl", "geo.owl"]) or \
                     ((iri.split(";"))[-1] in ["ino.owl"]): # More edge cases
                         version_tag = b'owl:versionInfo xml:lang=\"en\">([^<]+)'
                         version_search = re.search(version_tag, owl_string)  # type: ignore


### PR DESCRIPTION
Parse `geo` version so it isn't just whitespace; also clear out S3 and tracking for `geo`