### PR TITLE
Fix stats upload and don't create redundant validations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,6 @@ pipeline {
                                     sh '. venv/bin/activate && env && python3.8 run.py --s3_test --bucket fake_bucket --no_dl_progress'
                                 } else {
                                     sh '. venv/bin/activate && env && python3.8 run.py --bucket kg-hub-public-data --no_dl_progress --force_index_refresh'
-                                    sh '. venv/bin/activate && s3cmd -c $S3CMD_CFG --acl-public --mime-type=plain/text --cf-invalidate put -r stats/ s3://kg-hub-public-data/$S3PROJECTDIR/'
                                 }
                             }
                             

--- a/kg_obo/stats.py
+++ b/kg_obo/stats.py
@@ -506,6 +506,7 @@ def robot_axiom_validations(bucket: str, remote_path: str,
             # and load its output
             if need_metrics:
                 if measure_owl(robot_path, outpath, logpath, robot_env):
+                    print(f"Generated new ROBOT metrics for {name}, version {version}.")
                     pass
                 else:
                     print(f"Failed to obtain metrics for {name}, version {version}.")

--- a/kg_obo/stats.py
+++ b/kg_obo/stats.py
@@ -495,10 +495,12 @@ def robot_axiom_validations(bucket: str, remote_path: str,
             try:
                 remote_metrics = f'kg-obo/{name}/{version}/{name}-owl-profile-validation.tsv'
                 client.head_object(Bucket=bucket, Key=remote_metrics)
+                print(f"Will download existing metrics for {name}, version {version}.")
                 client.download_file(bucket, remote_metrics, logpath)
                 need_metrics = False
             except botocore.exceptions.ClientError:
                 need_metrics = True
+                print(f"Will get metrics for {name}, version {version}.")
 
             # Run robot measure to get stats we'll use for comparison
             # and load its output
@@ -508,7 +510,11 @@ def robot_axiom_validations(bucket: str, remote_path: str,
                 else:
                     print(f"Failed to obtain metrics for {name}, version {version}.")
                     continue
-            metrics = parse_robot_metrics(logpath, wanted_metrics)
+            try:
+                metrics = parse_robot_metrics(logpath, wanted_metrics)
+            except FileNotFoundError: # If we still don't have metrics
+                print(f"No metrics could be obtained for {name}, version {version}.")
+                continue
             
             # Load the graph
             edges_path = os.path.join(outdir,f"{name}_kgx_tsv_edges.tsv")

--- a/kg_obo/stats.py
+++ b/kg_obo/stats.py
@@ -483,21 +483,32 @@ def robot_axiom_validations(bucket: str, remote_path: str,
             try:
                 # Check if it exists first
                 client.head_object(Bucket=bucket, Key=remote_loc)
-                client.download_file(bucket, 
-                                    remote_loc,
-                                    outpath)
+                client.download_file(bucket, remote_loc, outpath)
             except botocore.exceptions.ClientError as e:
                 print(f"Could not retrieve OWL for {name}, version {version} due to: {e}")
                 shutil.rmtree(logdir)
                 continue
 
+            # Check to see if we already have robot measure results
+            # to avoid a redundant operation.
+            # If we have 'em, download 'em
+            try:
+                remote_metrics = f'kg-obo/{name}/{version}/{name}-owl-profile-validation.tsv'
+                client.head_object(Bucket=bucket, Key=remote_metrics)
+                client.download_file(bucket, remote_metrics, logpath)
+                need_metrics = False
+            except botocore.exceptions.ClientError:
+                need_metrics = True
+
             # Run robot measure to get stats we'll use for comparison
             # and load its output
-            if measure_owl(robot_path, outpath, logpath, robot_env):
-                metrics = parse_robot_metrics(logpath, wanted_metrics)
-            else:
-                print(f"Failed to obtain metrics for {name}, version {version}.")
-                continue
+            if need_metrics:
+                if measure_owl(robot_path, outpath, logpath, robot_env):
+                    pass
+                else:
+                    print(f"Failed to obtain metrics for {name}, version {version}.")
+                    continue
+            metrics = parse_robot_metrics(logpath, wanted_metrics)
             
             # Load the graph
             edges_path = os.path.join(outdir,f"{name}_kgx_tsv_edges.tsv")


### PR DESCRIPTION
Fix #157 

Also don't generate ROBOT reports for OBOs if we already have them, as this is redundant.
Download them from the bucket instead.